### PR TITLE
Minor Training Changes

### DIFF
--- a/bin/trainPlayers
+++ b/bin/trainPlayers
@@ -149,20 +149,20 @@ function trainPlayer(playerObject) {
         player.endurance = increment(player.endurance, .5, player.enduranceCap)
         player.toughness = decrement(player.toughness, .25, player.toughnessCap)
         player.vision = decrement(player.vision, .25, player.visionCap)
-        player.morale = increment(player.morale, 1)
+        player.morale = decrement(player.morale, 0.25)
         player.energy = decrement(player.energy, 5)
-        player.leadership = increment(player.leadership, .25)
+       player.leadership = increment(player.leadership, 0)
     } else if (player.regimen.value === 'Guard') {
         // primary skill blocking, secondary toughness and throwing
         player.blocking = increment(player.blocking, 1.5, player.blockingCap)
-        player.throwing = increment(player.throwing, .5, player.throwingCap)
+        player.throwing = decrement(player.throwing, 0.25, player.throwingCap)
         player.passing = decrement(player.passing, .25, player.passingCap)
-        player.endurance = decrement(player.endurance, .25, player.enduranceCap)
+        player.endurance = increment(player.endurance, 0.5, player.enduranceCap)
         player.toughness = increment(player.toughness, .5, player.toughnessCap)
         player.vision = decrement(player.vision, .25, player.visionCap)
-        player.morale = increment(player.morale, 1)
+        player.morale = decrement(player.morale, 0.25)
         player.energy = decrement(player.energy, 5)
-        player.leadership = increment(player.leadership, .25)
+        player.leadership = increment(player.leadership, 0)
     } else if (player.regimen.value === 'Center') {
         // primary skill throwing, secondary vision and endurance
         player.blocking = decrement(player.blocking, .25, player.blockingCap) 
@@ -171,9 +171,9 @@ function trainPlayer(playerObject) {
         player.endurance = increment(player.endurance, .5, player.enduranceCap)
         player.toughness = decrement(player.toughness, .25, player.toughnessCap)
         player.vision = increment(player.vision, .5, player.visionCap)
-        player.morale = increment(player.morale, 1)
+        player.morale = decrement(player.morale, 0.25)
         player.energy = decrement(player.energy, 5)
-		player.leadership = increment(player.leadership, .25)
+		player.leadership = increment(player.leadership, 0)
     } else if (player.regimen.value === 'General') {
         // all skills unchanged with a slow energy recovery
         player.blocking = increment(player.blocking, .0, player.blockingCap) 
@@ -182,9 +182,9 @@ function trainPlayer(playerObject) {
         player.endurance = increment(player.endurance, .0, player.enduranceCap)
         player.toughness = increment(player.toughness, .0, player.toughnessCap)
         player.vision = increment(player.vision, .0, player.visionCap)
-        player.morale = increment(player.morale, 1)
+        player.morale = increment(player.morale, 0.25)
         player.energy = increment(player.energy, 2)
-		player.leadership = increment(player.leadership, .25)
+		player.leadership = increment(player.leadership, .5)
     } else if (player.regimen.value === 'Rest') {
         // all skills suffer .25 decay with a fast energy recovery
         player.blocking = decrement(player.blocking, .25, player.blockingCap) 
@@ -195,7 +195,7 @@ function trainPlayer(playerObject) {
         player.vision = decrement(player.vision, .25, player.visionCap)
         player.morale = increment(player.morale, 5)
         player.energy = increment(player.energy, 10)
-        player.leadership = increment(player.leadership, .25)
+        player.leadership = decrement(player.leadership, .25)
     } else {
         // no training selected
         // all skills suffer .25 decay with a slow energy recovery
@@ -206,7 +206,7 @@ function trainPlayer(playerObject) {
         player.toughness = decrement(player.toughness, .25, player.toughnessCap)
         player.vision = decrement(player.vision, .25, player.visionCap)
         player.morale = decrement(player.morale, .25)
-        player.energy = increment(player.energy, 2)
+        player.energy = increment(player.energy, 5)
         player.leadership = decrement(player.leadership, 1)
     }
     player = updatePlayerValue(player)


### PR DESCRIPTION
Makes minor changes to training regimens to fix oddness in Guards getting Throwing bonus vs. Passing.
Leadership changes to reduce massive across-the-board leadership gains just for training Anything. Instead it's moved to General to incentivize using that.
Morale is reduced by focused training - Too much training not only tires you but reduces your morale. General training and Rest increases morale.

Not sure entirely about numbers for Morale / Leadership as I'm not sure whether/how much they change during the course of a match.

Details below.
GUARD:
swaps Throwing and Passing. (Guards shoot less than they pass)
Throwing now decremented by 0.25 and Passing now incremented by 0.5.
LEADERSHIP:
Rest -0.25 from +0.25
Wing/Guard/Centre: 0 from +0.25
General +0.5 from +0.25
MORALE:
Wing/Guard/Centre: (-0.25) from (+1.0)
General +0.25 from +1.0
ENERGY:
None +5 from +2.